### PR TITLE
Only cleanup temporary files when "saveOnly" option is not set

### DIFF
--- a/src/main/java/org/ilastik/ilastik4ij/IlastikPixelClassificationPrediction.java
+++ b/src/main/java/org/ilastik/ilastik4ij/IlastikPixelClassificationPrediction.java
@@ -135,14 +135,16 @@ public class IlastikPixelClassificationPrediction implements Command {
                 {
                     log.warn("something went wrong during processing ilastik pixel classification");
                 }
-                finally{
-                    log.info("Cleaning up");
-                    // get rid of temporary files
-                    if(tempInFileName != null)
-                        new File(tempInFileName).delete();
-                    if(tempOutFileName != null)
-                        new File(tempOutFileName).delete();
-                }
+				finally {
+					if (!saveOnly) {
+						log.info("Cleaning up");
+						// get rid of temporary files
+						if (tempInFileName != null)
+							new File(tempInFileName).delete();
+						if (tempOutFileName != null)
+							new File(tempOutFileName).delete();
+					}
+				}
         }
 
         private void runIlastik(String tempInFileName, String tempOutFileName) {


### PR DESCRIPTION
Otherwise the files are deleted before we can import them into ilastik for training, which defeats the whole purpose of this option.