### PR TITLE
Fix H5 slice indexing during H5 reading

### DIFF
--- a/src/main/java/org/ilastik/ilastik4ij/hdf5/Hdf5DataSetConfig.java
+++ b/src/main/java/org/ilastik/ilastik4ij/hdf5/Hdf5DataSetConfig.java
@@ -43,8 +43,11 @@ public class Hdf5DataSetConfig {
         typeInfo = Hdf5Utils.getTypeInfo(dsInfo);
     }
 
-    public int getExtent(char axis) {
-        return this.axisExtents.get(axis);
+    /**
+     * @return true if X axis is before Y, or false otherwise
+     */
+    public boolean isXYOrder() {
+        return axisIndices.get('x') < axisIndices.get('y');
     }
 
     public long[] getSliceOffset(int t, int z, int c) {

--- a/src/main/java/org/ilastik/ilastik4ij/hdf5/Hdf5DataSetReader.java
+++ b/src/main/java/org/ilastik/ilastik4ij/hdf5/Hdf5DataSetReader.java
@@ -22,7 +22,8 @@ import org.scijava.log.LogService;
 
 import javax.swing.*;
 import java.nio.file.Paths;
-import java.util.*;
+import java.util.Arrays;
+import java.util.List;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
@@ -92,11 +93,13 @@ public class Hdf5DataSetReader<T extends NativeType<T>> {
                             rai.setPosition(x, AXES.indexOf(Axes.X));
                             for (int y = 0; y < dsConfig.dimY; y++) {
                                 rai.setPosition(y, AXES.indexOf(Axes.Y));
-                                int destIndex = y * dsConfig.dimX + x;
-                                if (dsConfig.getExtent('x') < dsConfig.getExtent('y')) {
-                                    destIndex = x * dsConfig.dimY + y;
-                                }
 
+                                int destIndex;
+                                if (dsConfig.isXYOrder()) {
+                                    destIndex = x * dsConfig.dimY + y;
+                                } else {
+                                    destIndex = y * dsConfig.dimX + x;
+                                }
 
                                 if (type instanceof FloatType) {
                                     FloatType raiType = (FloatType) rai.get();


### PR DESCRIPTION
Make sure that the slice read from the H5 file is correctly indexed depending on the XY/YX axis order.