### PR TITLE
IlastikOptions: load parameters explicitly

### DIFF
--- a/src/main/java/org/ilastik/ilastik4ij/ui/IlastikOptions.java
+++ b/src/main/java/org/ilastik/ilastik4ij/ui/IlastikOptions.java
@@ -30,14 +30,17 @@ public class IlastikOptions extends OptionsPlugin {
     private int maxRamMb = 4096;
 
     public File getExecutableFile() {
+        load();
         return executableFile;
     }
 
     public int getMaxRamMb() {
+        load();
         return maxRamMb;
     }
 
     public int getNumThreads() {
+        load();
         return numThreads;
     }
 


### PR DESCRIPTION
The explicit loading of parameters in the accessors is required so that the parameters always reflect the state provided by a PrefService. We will need this for a custom preference pane in the KNIME ilastik integration to work with the plugin.