### PR TITLE
explicitly state the ordering of the input axes

### DIFF
--- a/src/main/java/org/ilastik/ilastik4ij/executors/ObjectClassification.java
+++ b/src/main/java/org/ilastik/ilastik4ij/executors/ObjectClassification.java
@@ -34,6 +34,7 @@ public class ObjectClassification extends AbstractIlastikExecutor {
         commandLine.add("--output_filename_format=" + tempFiles.get(outputTempFile));
         commandLine.add("--output_format=hdf5");
         commandLine.add("--output_axis_order=tzyxc");
+        commandLine.add("--input_axes=tzyxc");
         commandLine.add("--raw_data=" + tempFiles.get(rawInputTempFile));
 
         if (secondInputType == PixelPredictionType.Segmentation) {

--- a/src/main/java/org/ilastik/ilastik4ij/executors/PixelClassification.java
+++ b/src/main/java/org/ilastik/ilastik4ij/executors/PixelClassification.java
@@ -36,6 +36,7 @@ public class PixelClassification extends AbstractIlastikExecutor {
         if (pixelPredictionType == PixelPredictionType.Segmentation) {
             commandLine.add("--export_source=Simple Segmentation");
         }
+        commandLine.add("--input_axes=tzyxc");
         commandLine.add(tempFiles.get(rawInputTempFile));
 
         return commandLine;

--- a/src/main/java/org/ilastik/ilastik4ij/executors/Tracking.java
+++ b/src/main/java/org/ilastik/ilastik4ij/executors/Tracking.java
@@ -33,6 +33,7 @@ public class Tracking extends AbstractIlastikExecutor {
         commandLine.add("--output_format=hdf5");
         commandLine.add("--output_axis_order=tzyxc");
         commandLine.add("--export_source=Tracking-Result");
+        commandLine.add("--input_axes=tzyxc");
         commandLine.add("--raw_data=" + tempFiles.get(rawInputTempFile));
 
         if (pixelPredictionType == PixelPredictionType.Segmentation) {


### PR DESCRIPTION
This is a quick fix.
We always write out the data to a tmp folder, and always in the same axes ordering. Currently, this is not understood by ilastik (where the default is `tczyx` vs our plugin `tzyxc`). Therefore stating this when running the workflow resolves this issue. @tischer just to get you involved. Cannot add you as a reviewer.