### PR TITLE
Add ciManagement in pom.xml

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -66,7 +66,8 @@
         <url>http://github.com/ilastik/ilastik4ij/issues</url>
     </issueManagement>
     <ciManagement>
-        <system>None</system>
+        <system>Travis CI</system>
+        <url>https://travis-ci.org/ilastik/ilastik4ij</url>
     </ciManagement>
 
     <properties>


### PR DESCRIPTION
This should fix deployment to `maven.scijava.org`, and, with the next release, will hopefully fix #41.
