### PR TITLE
Fix macro recording in PixelClassification/ObjectClassification/Tracking 

### DIFF
--- a/src/main/java/org/ilastik/ilastik4ij/ui/DisplayUtils.java
+++ b/src/main/java/org/ilastik/ilastik4ij/ui/DisplayUtils.java
@@ -3,7 +3,6 @@ package org.ilastik.ilastik4ij.ui;
 import ij.IJ;
 import net.imagej.ImgPlus;
 import net.imglib2.img.display.imagej.ImageJFunctions;
-import org.ilastik.ilastik4ij.executors.AbstractIlastikExecutor.PixelPredictionType;
 import org.scijava.ui.UIService;
 
 public class DisplayUtils {
@@ -21,13 +20,9 @@ public class DisplayUtils {
         applyLUT(GLASBEY_INVERTED);
     }
 
-    public static void showOutput(UIService uiService, ImgPlus<?> predictions, PixelPredictionType pixelPredictionType) {
+    public static void showOutput(UIService uiService, ImgPlus<?> predictions) {
         if (!uiService.isHeadless()) {
             ImageJFunctions.show((ImgPlus) predictions);
-
-            if (pixelPredictionType == PixelPredictionType.Segmentation) {
-                DisplayUtils.applyGlasbeyLUT();
-            }
         }
     }
 }

--- a/src/main/java/org/ilastik/ilastik4ij/ui/IlastikObjectClassificationCommand.java
+++ b/src/main/java/org/ilastik/ilastik4ij/ui/IlastikObjectClassificationCommand.java
@@ -74,6 +74,6 @@ public class IlastikObjectClassificationCommand implements Command {
 
         this.predictions = objectClassification.classifyObjects(inputImage.getImgPlus(), inputProbOrSegImage.getImgPlus(), secondInputImageType);
 
-        DisplayUtils.showOutput(uiService, predictions, PixelPredictionType.Segmentation);
+        DisplayUtils.showOutput(uiService, predictions);
     }
 }

--- a/src/main/java/org/ilastik/ilastik4ij/ui/IlastikObjectClassificationCommand.java
+++ b/src/main/java/org/ilastik/ilastik4ij/ui/IlastikObjectClassificationCommand.java
@@ -74,6 +74,6 @@ public class IlastikObjectClassificationCommand implements Command {
 
         this.predictions = objectClassification.classifyObjects(inputImage.getImgPlus(), inputProbOrSegImage.getImgPlus(), secondInputImageType);
 
-        DisplayUtils.showOutput(uiService, predictions);
+        // DisplayUtils.showOutput(uiService, predictions);
     }
 }

--- a/src/main/java/org/ilastik/ilastik4ij/ui/IlastikPixelClassificationCommand.java
+++ b/src/main/java/org/ilastik/ilastik4ij/ui/IlastikPixelClassificationCommand.java
@@ -40,7 +40,7 @@ public class IlastikPixelClassificationCommand implements Command {
     public Dataset inputImage;
 
     @Parameter(label = "Output type", choices = {UiConstants.PIXEL_PREDICTION_TYPE_PROBABILITIES, UiConstants.PIXEL_PREDICTION_TYPE_SEGMENTATION}, style = "radioButtonHorizontal")
-    public String pixelClassificationType = UiConstants.PIXEL_PREDICTION_TYPE_PROBABILITIES;
+    public String pixelClassificationType;
 
     @Parameter(type = ItemIO.OUTPUT)
     private ImgPlus<? extends NativeType<?>> predictions;
@@ -71,6 +71,6 @@ public class IlastikPixelClassificationCommand implements Command {
         PixelPredictionType pixelPredictionType = PixelPredictionType.valueOf(pixelClassificationType);
         this.predictions = pixelClassification.classifyPixels(inputImage.getImgPlus(), pixelPredictionType);
 
-        DisplayUtils.showOutput(uiService, predictions, pixelPredictionType);
+        DisplayUtils.showOutput(uiService, predictions);
     }
 }

--- a/src/main/java/org/ilastik/ilastik4ij/ui/IlastikPixelClassificationCommand.java
+++ b/src/main/java/org/ilastik/ilastik4ij/ui/IlastikPixelClassificationCommand.java
@@ -71,6 +71,6 @@ public class IlastikPixelClassificationCommand implements Command {
         PixelPredictionType pixelPredictionType = PixelPredictionType.valueOf(pixelClassificationType);
         this.predictions = pixelClassification.classifyPixels(inputImage.getImgPlus(), pixelPredictionType);
 
-        DisplayUtils.showOutput(uiService, predictions);
+        // DisplayUtils.showOutput(uiService, predictions);
     }
 }

--- a/src/main/java/org/ilastik/ilastik4ij/ui/IlastikTrackingCommand.java
+++ b/src/main/java/org/ilastik/ilastik4ij/ui/IlastikTrackingCommand.java
@@ -74,6 +74,6 @@ public class IlastikTrackingCommand implements Command {
         this.predictions = tracking.trackObjects(inputImage.getImgPlus(), inputProbOrSegImage.getImgPlus(),
                 PixelPredictionType.valueOf(secondInputType));
 
-        DisplayUtils.showOutput(uiService, predictions, PixelPredictionType.Segmentation);
+        DisplayUtils.showOutput(uiService, predictions);
     }
 }

--- a/src/main/java/org/ilastik/ilastik4ij/ui/IlastikTrackingCommand.java
+++ b/src/main/java/org/ilastik/ilastik4ij/ui/IlastikTrackingCommand.java
@@ -74,6 +74,6 @@ public class IlastikTrackingCommand implements Command {
         this.predictions = tracking.trackObjects(inputImage.getImgPlus(), inputProbOrSegImage.getImgPlus(),
                 PixelPredictionType.valueOf(secondInputType));
 
-        DisplayUtils.showOutput(uiService, predictions);
+        // DisplayUtils.showOutput(uiService, predictions);
     }
 }


### PR DESCRIPTION
Using `DisplayUtils` with 'Segmentation' as an output type triggers another command which applies the LUT on the output. For some reason this prevents the macro to record the parameters of the command correctly. Skipping the LUT command fixes the issue.

WARN: this will impact PixelClassification/ObjectClassification/Tracking, i.e. Glatsbey LUT won't be applied to the output implicitly and it up to the end user to apply the LUT.

Fixes https://github.com/ilastik/ilastik4ij/issues/46
Fixes https://github.com/ilastik/ilastik4ij/issues/45