### PR TITLE
Refactor: move common command line arguments to base class

### DIFF
--- a/src/main/java/org/ilastik/ilastik4ij/executors/AbstractIlastikExecutor.java
+++ b/src/main/java/org/ilastik/ilastik4ij/executors/AbstractIlastikExecutor.java
@@ -11,6 +11,7 @@ import org.scijava.log.LogService;
 
 import java.io.File;
 import java.io.IOException;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -35,6 +36,8 @@ public abstract class AbstractIlastikExecutor {
         Probabilities
     }
 
+    protected final List<String> baseCommand;
+
 
     public AbstractIlastikExecutor(File executableFilePath, File projectFileName, LogService logService,
                                    StatusService statusService, int numThreads, int maxRamMb) {
@@ -44,8 +47,26 @@ public abstract class AbstractIlastikExecutor {
         this.projectFileName = projectFileName;
         this.logService = logService;
         this.statusService = statusService;
+        this.baseCommand = Arrays.asList(
+            executableFilePath.getAbsolutePath(),
+            "--headless",
+            "--project=" + projectFileName.getAbsolutePath(),
+            "--output_format=hdf5",
+            "--output_axis_order=tzyxc",
+            "--input_axes=tzyxc",
+            "--readonly",
+            "--output_internal_path=exported_data",
+            "--input_axes=tzyxc"
+        );
     }
 
+    /*
+     * implementations of the buildCommandLine method need to call the following lines:
+     *       List<String> commandLine = new ArrayList<>();
+     *       commandLine.add(this.baseCommand);
+     * then add the appropriate workflow arguments with
+     *       commandLine.add("...");
+     */
     protected abstract List<String> buildCommandLine(Map<String, String> tempFiles, PixelPredictionType pixelPredictionType);
 
     protected <T extends NativeType<T>> ImgPlus<T> executeIlastik(ImgPlus<? extends RealType<?>> rawInputImg,

--- a/src/main/java/org/ilastik/ilastik4ij/executors/ObjectClassification.java
+++ b/src/main/java/org/ilastik/ilastik4ij/executors/ObjectClassification.java
@@ -27,14 +27,7 @@ public class ObjectClassification extends AbstractIlastikExecutor {
 
     @Override
     protected List<String> buildCommandLine(Map<String, String> tempFiles, PixelPredictionType secondInputType) {
-        List<String> commandLine = new ArrayList<>();
-        commandLine.add(executableFilePath.getAbsolutePath());
-        commandLine.add("--headless");
-        commandLine.add("--project=" + projectFileName.getAbsolutePath());
-        commandLine.add("--output_filename_format=" + tempFiles.get(outputTempFile));
-        commandLine.add("--output_format=hdf5");
-        commandLine.add("--output_axis_order=tzyxc");
-        commandLine.add("--input_axes=tzyxc");
+        List<String> commandLine = new ArrayList<>(this.baseCommand);
         commandLine.add("--raw_data=" + tempFiles.get(rawInputTempFile));
 
         if (secondInputType == PixelPredictionType.Segmentation) {
@@ -42,6 +35,8 @@ public class ObjectClassification extends AbstractIlastikExecutor {
         } else {
             commandLine.add("--prediction_maps=" + tempFiles.get(secondInputTempFile));
         }
+
+        commandLine.add("--output_filename_format=" + tempFiles.get(outputTempFile));
 
         return commandLine;
     }

--- a/src/main/java/org/ilastik/ilastik4ij/executors/PixelClassification.java
+++ b/src/main/java/org/ilastik/ilastik4ij/executors/PixelClassification.java
@@ -26,18 +26,12 @@ public class PixelClassification extends AbstractIlastikExecutor {
 
     @Override
     protected List<String> buildCommandLine(Map<String, String> tempFiles, PixelPredictionType pixelPredictionType) {
-        List<String> commandLine = new ArrayList<>();
-        commandLine.add(executableFilePath.getAbsolutePath());
-        commandLine.add("--headless");
-        commandLine.add("--project=" + projectFileName.getAbsolutePath());
-        commandLine.add("--output_filename_format=" + tempFiles.get(outputTempFile));
-        commandLine.add("--output_format=hdf5");
-        commandLine.add("--output_axis_order=tzyxc");
+        List<String> commandLine = new ArrayList<>(this.baseCommand);
         if (pixelPredictionType == PixelPredictionType.Segmentation) {
             commandLine.add("--export_source=Simple Segmentation");
         }
-        commandLine.add("--input_axes=tzyxc");
-        commandLine.add(tempFiles.get(rawInputTempFile));
+        commandLine.add("--raw_data=" + tempFiles.get(rawInputTempFile));
+        commandLine.add("--output_filename_format=" + tempFiles.get(outputTempFile));
 
         return commandLine;
     }

--- a/src/main/java/org/ilastik/ilastik4ij/executors/Tracking.java
+++ b/src/main/java/org/ilastik/ilastik4ij/executors/Tracking.java
@@ -25,15 +25,8 @@ public class Tracking extends AbstractIlastikExecutor {
 
     @Override
     protected List<String> buildCommandLine(Map<String, String> tempFiles, PixelPredictionType pixelPredictionType) {
-        List<String> commandLine = new ArrayList<>();
-        commandLine.add(executableFilePath.getAbsolutePath());
-        commandLine.add("--headless");
-        commandLine.add("--project=" + projectFileName.getAbsolutePath());
-        commandLine.add("--output_filename_format=" + tempFiles.get(outputTempFile));
-        commandLine.add("--output_format=hdf5");
-        commandLine.add("--output_axis_order=tzyxc");
+        List<String> commandLine = new ArrayList<>(this.baseCommand);
         commandLine.add("--export_source=Tracking-Result");
-        commandLine.add("--input_axes=tzyxc");
         commandLine.add("--raw_data=" + tempFiles.get(rawInputTempFile));
 
         if (pixelPredictionType == PixelPredictionType.Segmentation) {
@@ -41,6 +34,8 @@ public class Tracking extends AbstractIlastikExecutor {
         } else {
             commandLine.add("--prediction_maps=" + tempFiles.get(secondInputTempFile));
         }
+
+        commandLine.add("--output_filename_format=" + tempFiles.get(outputTempFile));
 
         return commandLine;
     }


### PR DESCRIPTION
Summary:

* moved all common command line arguments to base class
* explicitly specify `--raw_data` flag for Pixel Classifcation
* specify the `--readonly` flag
* specify the internal export path as `exported_data`

fixes #50, #49 