### PR TITLE
update pom scijava and adds converter from String to Dataset

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.scijava</groupId>
         <artifactId>pom-scijava</artifactId>
-        <version>26.0.0</version>
+        <version>28.0.0</version>
         <relativePath />
     </parent>
 

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.scijava</groupId>
         <artifactId>pom-scijava</artifactId>
-        <version>28.0.0</version>
+        <version>26.0.0</version>
         <relativePath />
     </parent>
 

--- a/src/main/java/org/ilastik/ilastik4ij/util/StringToDatasetConverter.java
+++ b/src/main/java/org/ilastik/ilastik4ij/util/StringToDatasetConverter.java
@@ -34,7 +34,6 @@ public class StringToDatasetConverter extends AbstractConverter<String, Dataset>
 
     @Override
     public <T> T convert(Object src, Class<T> dest) {
-        assert src instanceof String;
         String name = (String) src;
         // First conversion : String to ImagePlus
         ImagePlus imagePlus = cs.convert(name, ImagePlus.class);

--- a/src/main/java/org/ilastik/ilastik4ij/util/StringToDatasetConverter.java
+++ b/src/main/java/org/ilastik/ilastik4ij/util/StringToDatasetConverter.java
@@ -1,0 +1,47 @@
+package org.ilastik.ilastik4ij.util;
+
+import ij.ImagePlus;
+import net.imagej.Dataset;
+import org.scijava.Priority;
+import org.scijava.convert.AbstractDelegateConverter;
+import org.scijava.convert.Converter;
+import org.scijava.plugin.Plugin;
+
+/**
+ * Extra converter needed for IJ1 macro scripting:
+ *
+ * Converts a String (provided by an IJ1 macro script) to a Dataset by delegating
+ * the conversion to a String to ImagePlus converter chained to an
+ * {@link ImagePlus} to {@link Dataset} converter
+ *
+ * This converter should be removed once this issue : https://github.com/imagej/imagej-legacy/issues/246
+ * is resolved
+ *
+ * See also :
+ * https://forum.image.sc/t/plugin-with-two-datasets-parameters-will-always-pop-up-gui-in-macro-runs/36637/11 *
+ * https://forum.image.sc/t/object-classification-using-the-ilastik-plugin-for-fiji/32997
+ *
+ * @author Nicolas Chiaruttini, Jan Eglinger
+ *
+ */
+
+@Plugin(type = Converter.class, priority = Priority.VERY_HIGH) // don't exaggerate priorities!
+public class StringToDatasetConverter extends
+        AbstractDelegateConverter<String, ImagePlus, Dataset>
+{
+
+    @Override
+    public Class<Dataset> getOutputType() {
+        return Dataset.class;
+    }
+
+    @Override
+    public Class<String> getInputType() {
+        return String.class;
+    }
+
+    @Override
+    protected Class<ImagePlus> getDelegateType() {
+        return ImagePlus.class;
+    }
+}


### PR DESCRIPTION
Adds a converter needed for IJ1 macro scripting:
 
 Converts a String (provided by an IJ1 macro script) to a Dataset by delegating
 the conversion to a String to ImagePlus converter chained to an
 {@link ImagePlus} to {@link Dataset} converter
 
 This converter should be removed once this issue : https://github.com/imagej/imagej-legacy/issues/246 is resolved

 See also :
 https://forum.image.sc/t/plugin-with-two-datasets-parameters-will-always-pop-up-gui-in-macro-runs/36637/11 

https://forum.image.sc/t/object-classification-using-the-ilastik-plugin-for-fiji/32997

I did not try completely whether all issues were resolved with this  - can you test whether that solves the batch issues you were mentioning @k-dominik ?

@imagejan I tried to put as much documentation as possible on the converter and also post on the issue in imagej-legacy. What do you think ? Does that sound reasonable for the moment ?