### PR TITLE
Implements Prediction Mask for Pixel Classification

### DIFF
--- a/src/main/java/org/ilastik/ilastik4ij/executors/PixelClassification.java
+++ b/src/main/java/org/ilastik/ilastik4ij/executors/PixelClassification.java
@@ -20,8 +20,9 @@ public class PixelClassification extends AbstractIlastikExecutor {
     }
 
     public <T extends NativeType<T>> ImgPlus<T> classifyPixels(ImgPlus<? extends RealType<?>> rawInputImg,
+                                                               ImgPlus<? extends RealType<?>> predictionMask,
                                                                PixelPredictionType pixelPredictionType) throws IOException {
-        return executeIlastik(rawInputImg, null, pixelPredictionType);
+        return executeIlastik(rawInputImg, predictionMask, pixelPredictionType);
     }
 
     @Override
@@ -35,6 +36,10 @@ public class PixelClassification extends AbstractIlastikExecutor {
         }
         commandLine.add("--raw_data=" + tempFiles.get(rawInputTempFile));
         commandLine.add("--output_filename_format=" + tempFiles.get(outputTempFile));
+
+        if(tempFiles.containsKey(secondInputTempFile)){
+            commandLine.add("--prediction_mask=" + tempFiles.get(secondInputTempFile));
+        }
 
         return commandLine;
     }

--- a/src/test/java/org/ilastik/ilastik4ij/PixelClassificationDemo.java
+++ b/src/test/java/org/ilastik/ilastik4ij/PixelClassificationDemo.java
@@ -62,7 +62,7 @@ public class PixelClassificationDemo {
                 1024
         );
 
-        final ImgPlus<T> classifiedPixels = prediction.classifyPixels(inputDataset.getImgPlus(), PixelPredictionType.Probabilities);
+        final ImgPlus<T> classifiedPixels = prediction.classifyPixels(inputDataset.getImgPlus(), null, PixelPredictionType.Probabilities);
 
         ImageJFunctions.show(classifiedPixels, "Probability maps");
     }


### PR DESCRIPTION
This still doesn't work as a backwards compatible macro,
since using pixel classification as a macro will require the
value for 'useMask'.

I could not find a way to have this extra parameter with a default
value that would be picked up also by the macro usage. Either
the input is marked as resolved and doesn't show up in the UI,
or it is not marked as resolved, but requires the macro usage to specify
the value interactively.

fixes #7