### PR TITLE
for discussion, run macro via imagej api

### DIFF
--- a/src/test/java/org/ilastik/ilastik4ij/ImportMacroRegressionTests.java
+++ b/src/test/java/org/ilastik/ilastik4ij/ImportMacroRegressionTests.java
@@ -1,0 +1,22 @@
+package org.ilastik.ilastik4ij;
+
+import ij.ImagePlus;
+import org.junit.Test;
+import ij.IJ;
+import static org.junit.Assert.assertEquals;
+
+public class ImportMacroRegressionTests {
+    private static final String TEST_MACRO_RESOURCE = "src/test/resources/import-1.7.3.ijm";
+
+    @Test
+    public void testHeadlessRun() {
+        IJ.runMacroFile(TEST_MACRO_RESOURCE);
+        ImagePlus img = IJ.getImage();
+        int[] imgDims = img.getDimensions();
+        assertEquals("DimX should be 1344", 1344, imgDims[0]);
+        assertEquals("DimY should be 1024", 1024, imgDims[1]);
+        assertEquals("DimC should be 1", 1, imgDims[2]);
+        assertEquals("DimZ should be 1", 1, imgDims[3]);
+        assertEquals("DimT should be 1", 1, imgDims[4]);
+    }
+}

--- a/src/test/resources/import-1.7.3.ijm
+++ b/src/test/resources/import-1.7.3.ijm
@@ -1,0 +1,1 @@
+run("Import HDF5", "select=src/test/resources/2d_cells_apoptotic_1channel.h5 datasetname=[/data: (1, 1, 1024, 1344, 1) uint8] axisorder=tzyxc");


### PR DESCRIPTION
I think it would be nice running macros as integration tests. But I'm not sure what the best way would be to do it. It works using the ImageJ api, but it will fire up a gui (so CI will probably fail, or we need to xvfb-run it).
My vision would be to also install ilastik on CI and run integration tests for the other workflows, too. Any opinions?

cc @emilmelnikov @m-novikov @Tomaz-Vieira 