### PR TITLE
supply (optional) readonly value explicitly

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,8 @@ Within ImageJ/Fiji you can install the plugin via the `Help -> Update` menu and 
 
 **Note**: The plugins need Java 1.8, if you see error messages popping up that might be caused by an older Java version.
 
+**Compatibility note:**: We try to keep the plugin backwards compatible. Some versions of ilastik are _not_ compatible with the current plugin: `1.3.3b2`,  `1.3.3rc2`, `1.3.3`, `1.3.3post1`, `1.3.3post2`. _We recommend to update to the latest stable version!. If you need to stick with `1.3.3x` for some reason, please use `1.3.3post3`._
+
 ## User documentation
 
 The ilastik workflow wrappers, as well as importer and exporter, can be found in ImageJ under `Plugins -> ilastik`, 

--- a/src/main/java/org/ilastik/ilastik4ij/executors/AbstractIlastikExecutor.java
+++ b/src/main/java/org/ilastik/ilastik4ij/executors/AbstractIlastikExecutor.java
@@ -52,7 +52,7 @@ public abstract class AbstractIlastikExecutor {
             "--output_format=hdf5",
             "--output_axis_order=tzyxc",
             "--input_axes=tzyxc",
-            "--readonly",
+            "--readonly=1",
             "--output_internal_path=exported_data",
             "--input_axes=tzyxc"
         );


### PR DESCRIPTION
the cmd interface of 1.3.2 needs a value with the readonly flag. In order to support this version, we can specify. Works with newer versions, too.