### PR TITLE
Add ImageJ command for listing HDF5 datasets

### DIFF
--- a/src/main/java/org/ilastik/ilastik4ij/hdf5/DatasetEntryProvider.java
+++ b/src/main/java/org/ilastik/ilastik4ij/hdf5/DatasetEntryProvider.java
@@ -2,7 +2,9 @@ package org.ilastik.ilastik4ij.hdf5;
 
 import hdf.hdf5lib.exceptions.HDF5Exception;
 
+import java.util.Arrays;
 import java.util.List;
+import java.util.stream.Collectors;
 
 public interface DatasetEntryProvider {
     List<DatasetEntry> findAvailableDatasets(String path);
@@ -15,16 +17,23 @@ public interface DatasetEntryProvider {
 
     class DatasetEntry {
         public final String path;
+        public final long[] shape;
+        public final String dtype;
         public final String axisTags;
-        public final String verboseName;
-        public final int rank;
 
-        public DatasetEntry(String path, int rank, String axisTags, String verboseName) {
+        public DatasetEntry(String path, long[] shape, String dtype, String axisTags) {
             this.path = path;
-            this.rank = rank;
+            this.shape = shape;
+            this.dtype = dtype;
             this.axisTags = axisTags;
-            this.verboseName = verboseName;
         }
 
+        @Override
+        public String toString() {
+            String shapeString = Arrays.stream(shape)
+                    .mapToObj(String::valueOf)
+                    .collect(Collectors.joining(", "));
+            return String.format("%s (%s) %s", path, shapeString, dtype);
+        }
     }
 }

--- a/src/main/java/org/ilastik/ilastik4ij/hdf5/HDF5DatasetEntryProvider.java
+++ b/src/main/java/org/ilastik/ilastik4ij/hdf5/HDF5DatasetEntryProvider.java
@@ -48,16 +48,7 @@ public class HDF5DatasetEntryProvider implements DatasetEntryProvider {
             logService.debug("Invalid axistags attribute in dataset");
         }
 
-        return new DatasetEntry(internalPath, dsRank, axisTags, makeVerboseName(internalPath, hdf5DatasetInfo));
-    }
-
-    private static String makeVerboseName(String internalPath, HDF5DataSetInformation dsInfo) {
-        String shape = Arrays.stream(dsInfo.getDimensions())
-                .mapToObj(String::valueOf)
-                .collect(Collectors.joining(", "));
-
-        String dtype = Hdf5Utils.getTypeInfo(dsInfo);
-        return String.format("%s: (%s) %s", internalPath, shape, dtype);
+        return new DatasetEntry(internalPath, hdf5DatasetInfo.getDimensions(), Hdf5Utils.getTypeInfo(hdf5DatasetInfo), axisTags);
     }
 
     private static String defaultAxisOrder(int rank) {
@@ -87,7 +78,7 @@ public class HDF5DatasetEntryProvider implements DatasetEntryProvider {
                 switch (linkInfo.getType()) {
                     case DATASET:
                         DatasetEntry datasetEntry = getDatasetEntry(linkInfo.getPath(), reader);
-                        if (datasetEntry.rank >= 2) {
+                        if (datasetEntry.shape.length >= 2) {
                             result.add(datasetEntry);
                         }
                         break;

--- a/src/main/java/org/ilastik/ilastik4ij/ui/IlastikImportModel.java
+++ b/src/main/java/org/ilastik/ilastik4ij/ui/IlastikImportModel.java
@@ -118,7 +118,7 @@ class IlastikImportModel {
     }
 
     public List<String> getAvailableDatasetNames() {
-        return availableDatasets.stream().map(e -> e.verboseName).collect(Collectors.toList());
+        return availableDatasets.stream().map(Object::toString).collect(Collectors.toList());
     }
 
     public String getAxisTags() {
@@ -157,7 +157,7 @@ class IlastikImportModel {
                 }
             }
 
-            return availableDatasets.get(datasetIdx).rank == count;
+            return availableDatasets.get(datasetIdx).shape.length == count;
         } else {
             return false;
         }

--- a/src/main/java/org/ilastik/ilastik4ij/ui/ListHdf5DatasetsCommand.java
+++ b/src/main/java/org/ilastik/ilastik4ij/ui/ListHdf5DatasetsCommand.java
@@ -1,0 +1,54 @@
+package org.ilastik.ilastik4ij.ui;
+
+import org.ilastik.ilastik4ij.hdf5.DatasetEntryProvider;
+import org.ilastik.ilastik4ij.hdf5.HDF5DatasetEntryProvider;
+import org.scijava.ItemIO;
+import org.scijava.command.Command;
+import org.scijava.command.ContextCommand;
+import org.scijava.log.LogService;
+import org.scijava.plugin.Parameter;
+import org.scijava.plugin.Plugin;
+import org.scijava.table.DefaultGenericTable;
+import org.scijava.table.GenericTable;
+
+import java.io.File;
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Plugin(type = Command.class, headless = true, menuPath = "Plugins>ilastik>List HDF5 Datasets")
+public class ListHdf5DatasetsCommand extends ContextCommand {
+    @Parameter
+    public File file;
+
+    @SuppressWarnings("unused")
+    @Parameter
+    private LogService logService;
+
+    @Parameter(type = ItemIO.OUTPUT)
+    public GenericTable datasets;
+
+    @Override
+    public void run() {
+        List<DatasetEntryProvider.DatasetEntry> entries = new HDF5DatasetEntryProvider(logService).findAvailableDatasets(file.toString());
+
+        datasets = new DefaultGenericTable(4, entries.size());
+        datasets.setColumnHeader(0, "Path");
+        datasets.setColumnHeader(1, "Shape");
+        datasets.setColumnHeader(2, "Data Type");
+        datasets.setColumnHeader(3, "Axis Tags");
+
+        for (int i = 0; i < entries.size(); i++) {
+            DatasetEntryProvider.DatasetEntry entry = entries.get(i);
+
+            String shapeString = Arrays.stream(entry.shape)
+                    .mapToObj(String::valueOf)
+                    .collect(Collectors.joining(","));
+
+            datasets.set(0, i, entry.path);
+            datasets.set(1, i, shapeString);
+            datasets.set(2, i, entry.dtype);
+            datasets.set(3, i, entry.axisTags);
+        }
+    }
+}

--- a/src/test/java/org/ilastik/ilastik4ij/hdf5/HDF5DatasetEntryProviderTest.java
+++ b/src/test/java/org/ilastik/ilastik4ij/hdf5/HDF5DatasetEntryProviderTest.java
@@ -29,8 +29,8 @@ public class HDF5DatasetEntryProviderTest extends TestCase {
 
         HDF5DatasetEntryProvider.DatasetEntry info = infos.get(0);
         assertEquals("/exported_data", info.path);
-        assertEquals("/exported_data: (7, 6, 5, 4, 3) uint16", info.verboseName);
         assertEquals("tzyxc", info.axisTags);
+        assertEquals("/exported_data: (7, 6, 5, 4, 3) uint16", info.toString());
     }
 
     public void testFindAvailableDatasets() {
@@ -40,12 +40,12 @@ public class HDF5DatasetEntryProviderTest extends TestCase {
 
         HDF5DatasetEntryProvider.DatasetEntry info = infos.get(0);
         assertEquals("/dataset_without_axes", info.path);
-        assertEquals("/dataset_without_axes: (64, 64) int64", info.verboseName);
         assertEquals("yx", info.axisTags);
+        assertEquals("/dataset_without_axes: (64, 64) int64", info.toString());
 
         HDF5DatasetEntryProvider.DatasetEntry info2 = infos.get(1);
         assertEquals("/exported_data", info2.path);
-        assertEquals("/exported_data: (256, 256, 256, 1) float32", info2.verboseName);
         assertEquals("zyxc", info2.axisTags);
+        assertEquals("/exported_data: (256, 256, 256, 1) float32", info2.toString());
     }
 }

--- a/src/test/java/org/ilastik/ilastik4ij/ui/IlastikImportModelTest.java
+++ b/src/test/java/org/ilastik/ilastik4ij/ui/IlastikImportModelTest.java
@@ -17,8 +17,8 @@ public class IlastikImportModelTest extends TestCase {
         @Override
         public List<DatasetEntry> findAvailableDatasets(String path) {
             List<DatasetEntry> result = new ArrayList<>();
-            result.add(new DatasetEntry("/firstDataset", 3, "xyc", "/firstDataset"));
-            result.add(new DatasetEntry("/secondDataset", 4, "xyzc", "/secondDataset"));
+            result.add(new DatasetEntry("/firstDataset", new long[]{100, 200, 3}, "float32", "xyc"));
+            result.add(new DatasetEntry("/secondDataset", new long[]{100, 200, 50, 3}, "uint8", "xyzc"));
             return result;
         }
     }


### PR DESCRIPTION
Also refactor DatasetEntry: save shape and dtype as fields, and move verboseName to the toString() method.

Closes https://github.com/ilastik/ilastik4ij/issues/93
