### PR TITLE
Add manual release to ImageJ action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,35 @@
+name: Release to Update Site
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: Plugin version
+        required: true
+        type: string
+
+jobs:
+  build_release:
+    runs-on: ubuntu-latest
+
+    env:
+      IJ_DOWNLOAD_URL: https://downloads.imagej.net/fiji/latest/fiji-linux64.zip
+      WIKI_USER: YOUR_USER_NAME
+      UPDATE_PASS: $
+      UPDATE_SITE: Ilastik
+
+    steps:
+      - name: Install ImageJ/Fiji
+        run: |
+          curl --silent --remote-name ${IJ_DOWNLOAD_URL}
+          unzip fiji-linux64.zip
+          ./Fiji.app/ImageJ-linux64 --headless --update edit-update-site ${UPDATE_SITE} https://sites.imagej.net/${UPDATE_SITE}/ "webdav:${WIKI_USER}:${UPDATE_PASS}" .
+
+      - name: Download plugin JAR into ImageJ/Fiji
+        run: curl \
+          --silent \
+          --remote-name https://maven.scijava.org/content/repositories/releases/org/ilastik/ilastik4ij/${{ inputs.version }}/ilastik4ij-${{ inputs.version }}.jar \
+          --output-dir ./Fiji.app/jars
+
+      - name: Release to ImageJ update site
+        run: ./Fiji.app/ImageJ-linux64 --headless --update upload-complete-site --force ${UPDATE_SITE}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,18 +12,16 @@ jobs:
   build_release:
     runs-on: ubuntu-latest
 
-    env:
-      IJ_DOWNLOAD_URL: https://downloads.imagej.net/fiji/latest/fiji-linux64.zip
-      WIKI_USER: YOUR_USER_NAME
-      UPDATE_PASS: $
-      UPDATE_SITE: Ilastik
+    environment:
+      name: release
+      url: https://sites.imagej.net/Ilastik/plugins/
 
     steps:
       - name: Install ImageJ/Fiji
         run: |
-          curl --silent --remote-name ${IJ_DOWNLOAD_URL}
+          curl --silent --remote-name https://downloads.imagej.net/fiji/latest/fiji-linux64.zip
           unzip fiji-linux64.zip
-          ./Fiji.app/ImageJ-linux64 --headless --update edit-update-site ${UPDATE_SITE} https://sites.imagej.net/${UPDATE_SITE}/ "webdav:${WIKI_USER}:${UPDATE_PASS}" .
+          ./Fiji.app/ImageJ-linux64 --headless --update edit-update-site ilastik https://sites.imagej.net/Ilastik/ "webdav:ilastik-ci:${{ secrets.UPDATE_PASS }}" .
 
       - name: Download plugin JAR into ImageJ/Fiji
         run: curl \
@@ -32,4 +30,4 @@ jobs:
           --output-dir ./Fiji.app/jars
 
       - name: Release to ImageJ update site
-        run: ./Fiji.app/ImageJ-linux64 --headless --update upload-complete-site --force ${UPDATE_SITE}
+        run: ./Fiji.app/ImageJ-linux64 --headless --update upload-complete-site --force ilastik


### PR DESCRIPTION
This workflow needs valid `WIKI_USER` and `UPDATE_PASS`.