### PR TITLE
Add demo for converting from/to ImagePlus

### DIFF
--- a/src/main/java/org/ilastik/ilastik4ij/workflow/AutocontextCommand.java
+++ b/src/main/java/org/ilastik/ilastik4ij/workflow/AutocontextCommand.java
@@ -1,6 +1,7 @@
 package org.ilastik.ilastik4ij.workflow;
 
 import net.imglib2.type.NativeType;
+import net.imglib2.type.numeric.RealType;
 import org.scijava.command.Command;
 import org.scijava.plugin.Parameter;
 import org.scijava.plugin.Plugin;
@@ -9,7 +10,7 @@ import java.util.Collections;
 import java.util.List;
 
 @Plugin(type = Command.class, headless = true, menuPath = "Plugins>ilastik>Run Autocontext Prediction")
-public final class AutocontextCommand<T extends NativeType<T>> extends WorkflowCommand<T> {
+public final class AutocontextCommand<T extends NativeType<T> & RealType<T>> extends WorkflowCommand<T> {
     @Parameter(label = "Output type", choices = {ROLE_PROBABILITIES, ROLE_SEGMENTATION}, style = "radioButtonHorizontal")
     public String AutocontextPredictionType;
 

--- a/src/main/java/org/ilastik/ilastik4ij/workflow/MulticutCommand.java
+++ b/src/main/java/org/ilastik/ilastik4ij/workflow/MulticutCommand.java
@@ -2,6 +2,7 @@ package org.ilastik.ilastik4ij.workflow;
 
 import net.imagej.Dataset;
 import net.imglib2.type.NativeType;
+import net.imglib2.type.numeric.RealType;
 import org.scijava.command.Command;
 import org.scijava.plugin.Parameter;
 import org.scijava.plugin.Plugin;
@@ -11,7 +12,7 @@ import java.util.List;
 import java.util.Map;
 
 @Plugin(type = Command.class, headless = true, menuPath = "Plugins>ilastik>Run Multicut")
-public final class MulticutCommand<T extends NativeType<T>> extends WorkflowCommand<T> {
+public final class MulticutCommand<T extends NativeType<T> & RealType<T>> extends WorkflowCommand<T> {
     @Parameter(label = "Boundary Prediction Image")
     public Dataset boundaryPredictionImage;
 

--- a/src/main/java/org/ilastik/ilastik4ij/workflow/ObjectClassificationCommand.java
+++ b/src/main/java/org/ilastik/ilastik4ij/workflow/ObjectClassificationCommand.java
@@ -2,6 +2,7 @@ package org.ilastik.ilastik4ij.workflow;
 
 import net.imagej.Dataset;
 import net.imglib2.type.NativeType;
+import net.imglib2.type.numeric.RealType;
 import org.scijava.command.Command;
 import org.scijava.plugin.Parameter;
 import org.scijava.plugin.Plugin;
@@ -10,7 +11,7 @@ import java.util.Collections;
 import java.util.Map;
 
 @Plugin(type = Command.class, headless = true, menuPath = "Plugins>ilastik>Run Object Classification Prediction")
-public final class ObjectClassificationCommand<T extends NativeType<T>> extends WorkflowCommand<T> {
+public final class ObjectClassificationCommand<T extends NativeType<T> & RealType<T>> extends WorkflowCommand<T> {
     @Parameter(label = "Pixel Probability or Segmentation image")
     public Dataset inputProbOrSegImage;
 

--- a/src/main/java/org/ilastik/ilastik4ij/workflow/PixelClassificationCommand.java
+++ b/src/main/java/org/ilastik/ilastik4ij/workflow/PixelClassificationCommand.java
@@ -1,6 +1,7 @@
 package org.ilastik.ilastik4ij.workflow;
 
 import net.imglib2.type.NativeType;
+import net.imglib2.type.numeric.RealType;
 import org.scijava.command.Command;
 import org.scijava.plugin.Parameter;
 import org.scijava.plugin.Plugin;
@@ -9,7 +10,7 @@ import java.util.Collections;
 import java.util.List;
 
 @Plugin(type = Command.class, headless = true, menuPath = "Plugins>ilastik>Run Pixel Classification Prediction")
-public final class PixelClassificationCommand<T extends NativeType<T>> extends WorkflowCommand<T> {
+public final class PixelClassificationCommand<T extends NativeType<T> & RealType<T>> extends WorkflowCommand<T> {
     @Parameter(label = "Output type", choices = {ROLE_PROBABILITIES, ROLE_SEGMENTATION}, style = "radioButtonHorizontal")
     public String pixelClassificationType;
 

--- a/src/main/java/org/ilastik/ilastik4ij/workflow/TrackingCommand.java
+++ b/src/main/java/org/ilastik/ilastik4ij/workflow/TrackingCommand.java
@@ -2,6 +2,7 @@ package org.ilastik.ilastik4ij.workflow;
 
 import net.imagej.Dataset;
 import net.imglib2.type.NativeType;
+import net.imglib2.type.numeric.RealType;
 import org.scijava.command.Command;
 import org.scijava.plugin.Parameter;
 import org.scijava.plugin.Plugin;
@@ -11,7 +12,7 @@ import java.util.List;
 import java.util.Map;
 
 @Plugin(type = Command.class, headless = true, menuPath = "Plugins>ilastik>Run Tracking")
-public final class TrackingCommand<T extends NativeType<T>> extends WorkflowCommand<T> {
+public final class TrackingCommand<T extends NativeType<T> & RealType<T>> extends WorkflowCommand<T> {
     @Parameter(label = "Pixel Probability or Segmentation image")
     public Dataset inputProbOrSegImage;
 

--- a/src/main/java/org/ilastik/ilastik4ij/workflow/WorkflowCommand.java
+++ b/src/main/java/org/ilastik/ilastik4ij/workflow/WorkflowCommand.java
@@ -3,6 +3,7 @@ package org.ilastik.ilastik4ij.workflow;
 import net.imagej.Dataset;
 import net.imagej.ImgPlus;
 import net.imglib2.type.NativeType;
+import net.imglib2.type.numeric.RealType;
 import org.ilastik.ilastik4ij.hdf5.Hdf5DataSetReader;
 import org.ilastik.ilastik4ij.hdf5.Hdf5DataSetWriter;
 import org.ilastik.ilastik4ij.ui.IlastikOptions;
@@ -36,7 +37,7 @@ import java.util.*;
  * Subclasses should be named as {@code [MyWorkflowName]Command}
  * because workflow names are derived from their corresponding class names.
  */
-public abstract class WorkflowCommand<T extends NativeType<T>> extends ContextCommand {
+public abstract class WorkflowCommand<T extends NativeType<T> & RealType<T>> extends ContextCommand {
     public static final String ROLE_PROBABILITIES = "Probabilities";
     public static final String ROLE_SEGMENTATION = "Segmentation";
 

--- a/src/test/java/org/ilastik/ilastik4ij/demo/ImagePlusDemo.java
+++ b/src/test/java/org/ilastik/ilastik4ij/demo/ImagePlusDemo.java
@@ -1,0 +1,78 @@
+package org.ilastik.ilastik4ij.demo;
+
+import ij.IJ;
+import ij.ImagePlus;
+import net.imagej.Dataset;
+import net.imagej.DefaultDataset;
+import net.imagej.ImageJ;
+import net.imagej.ImgPlus;
+import net.imglib2.img.ImagePlusAdapter;
+import net.imglib2.img.display.imagej.ImageJFunctions;
+import net.imglib2.type.NativeType;
+import net.imglib2.type.numeric.RealType;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.UncheckedIOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
+import java.util.Objects;
+
+/**
+ * Shows how to convert from and to {@link ImagePlus}.
+ */
+public final class ImagePlusDemo {
+    public static void main(String[] args) throws IOException {
+        ImageJ ij = new ImageJ();
+        ij.ui().showUI();
+
+        fromImagePlus(ij);
+        toImagePlus(ij);
+    }
+
+    private static <T extends NativeType<T> & RealType<T>> void fromImagePlus(ImageJ ij) {
+        ImagePlus imagePlus = IJ.openImage(fromResource("/2d_cells_apoptotic.tif"));
+        imagePlus.setTitle("ImagePlus");  // Change title just for the demonstration.
+        imagePlus.show();
+
+        ImgPlus<T> imgPlus = ImagePlusAdapter.wrapImgPlus(imagePlus);
+        ij.ui().show("ImgPlus", imgPlus);
+
+        DefaultDataset dataset = new DefaultDataset(ij.context(), imgPlus);
+        ij.ui().show("Dataset", dataset);
+    }
+
+    private static <T extends NativeType<T> & RealType<T>> void toImagePlus(ImageJ ij) throws IOException {
+        Dataset dataset = ij.scifio().datasetIO().open(fromResource("/2d_cells_apoptotic.tif"));
+        ij.ui().show("Dataset", dataset);
+
+        @SuppressWarnings("unchecked")
+        ImgPlus<T> imgPlus = (ImgPlus<T>) dataset.getImgPlus();
+        ij.ui().show("ImgPlus", imgPlus);
+
+        ImagePlus imagePlus = ImageJFunctions.wrap(imgPlus, imgPlus.getName());
+        imagePlus.setTitle("ImagePlus"); // Change title just for the demonstration.
+        imagePlus.show();
+    }
+
+    /**
+     * Copy resource to a temporary file and return the file path.
+     * <p>
+     * This function is used here just for the demonstration purposes.
+     * If you read files from a local disk, just use the path directly.
+     */
+    private static String fromResource(String resourcePath) {
+        try (InputStream in = WorkflowDemo.class.getResourceAsStream(resourcePath)) {
+            Path target = Files.createTempFile("", resourcePath.replace('/', '-'));
+            Files.copy(Objects.requireNonNull(in), target, StandardCopyOption.REPLACE_EXISTING);
+            return target.toString();
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+    }
+
+    private ImagePlusDemo() {
+        throw new AssertionError();
+    }
+}

--- a/src/test/java/org/ilastik/ilastik4ij/demo/WorkflowDemo.java
+++ b/src/test/java/org/ilastik/ilastik4ij/demo/WorkflowDemo.java
@@ -1,4 +1,4 @@
-package org.ilastik.ilastik4ij;
+package org.ilastik.ilastik4ij.demo;
 
 import net.imagej.Dataset;
 import net.imagej.ImageJ;
@@ -8,12 +8,16 @@ import org.ilastik.ilastik4ij.workflow.PixelClassificationCommand;
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
+import java.io.UncheckedIOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.StandardCopyOption;
 import java.util.Objects;
 
-public final class Demo {
+/**
+ * Shows how to run ilastik workflows.
+ */
+public final class WorkflowDemo {
     public static void main(String[] args) throws Exception {
         ImageJ ij = new ImageJ();
         ij.ui().showUI();
@@ -29,7 +33,7 @@ public final class Demo {
     }
 
     @SuppressWarnings("unused")
-    private static void pixelClassification(ImageJ ij) throws Exception {
+    private static void pixelClassification(ImageJ ij) throws IOException {
         Dataset inputImage = ij.scifio().datasetIO().open(fromResource("/2d_cells_apoptotic.tif"));
         ij.ui().show(inputImage);
 
@@ -44,7 +48,7 @@ public final class Demo {
     }
 
     @SuppressWarnings("unused")
-    private static void objectClassification(ImageJ ij) throws Exception {
+    private static void objectClassification(ImageJ ij) throws IOException {
         Dataset inputImage = ij.scifio().datasetIO().open(fromResource("/2d_cells_apoptotic.tif"));
         ij.ui().show(inputImage);
 
@@ -68,14 +72,17 @@ public final class Demo {
      * This function is used here just for the demonstration purposes.
      * If you read files from a local disk, just use the path directly.
      */
-    private static String fromResource(String resourcePath) throws IOException {
-        Path target = Files.createTempFile("", resourcePath.replace('/', '-'));
-        try (InputStream in = Demo.class.getResourceAsStream(resourcePath)) {
+    private static String fromResource(String resourcePath) {
+        try (InputStream in = WorkflowDemo.class.getResourceAsStream(resourcePath)) {
+            Path target = Files.createTempFile("", resourcePath.replace('/', '-'));
             Files.copy(Objects.requireNonNull(in), target, StandardCopyOption.REPLACE_EXISTING);
+            return target.toString();
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
         }
-        return target.toString();
     }
 
-    private Demo() {
+    private WorkflowDemo() {
+        throw new AssertionError();
     }
 }


### PR DESCRIPTION
ImagePlus is still heavily used by ImageJ1 users.

Also narrowed generic type bounds in Workflow classes to `NativeType<T> & RealType<T>`: it's more precise and allows one to call ImageJFunctions.wrap without casting.