### PR TITLE
explicit export source for object classification

### DIFF
--- a/src/main/java/org/ilastik/ilastik4ij/workflow/ObjectClassificationCommand.java
+++ b/src/main/java/org/ilastik/ilastik4ij/workflow/ObjectClassificationCommand.java
@@ -46,13 +46,7 @@ public final class ObjectClassificationCommand<T extends NativeType<T> & RealTyp
 
     @Override
     protected List<String> workflowArgs() {
-        if (ROLE_PROBABILITIES.equals(secondInputType)) {
-            return Collections.singletonList("--export_source=Object Probabilities");
-        }
-        if (ROLE_SEGMENTATION.equals(secondInputType)) {
-            return Collections.singletonList("--export_source=Object Predictions");
-        }
-        throw new IllegalStateException("Unexpected value: " + secondInputType);
+        return Collections.singletonList("--export_source=Object Predictions");
     }
 
     @Override


### PR DESCRIPTION
in the past nothing was passed to the workflow, which defaulted to `Object Predictions` output.
This makes it explicit and fixes the previous binding to input type. While it would be cool to choose the export source, and we should definitely do it, see #64.